### PR TITLE
Add Taiko Alethia mainnet skill and agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ claude --plugin-dir ./taiko-ai
 | Skill | Command | Description |
 |-------|---------|-------------|
 | Hoodi (testnet) | `/taiko:hoodi` | Deploy and test on Taiko Hoodi testnet |
-| Mainnet | `/taiko:mainnet` | *(Coming soon)* Deploy to Taiko mainnet |
+| Mainnet | `/taiko:mainnet` | Deploy to Taiko Alethia mainnet |
 
 ### /taiko:hoodi
 
@@ -37,34 +37,51 @@ Deploy, test, and interact with smart contracts on **Taiko Hoodi** (testnet).
 - Python and Solidity examples
 - Cross-chain messaging patterns
 
+### /taiko:mainnet
+
+Deploy, test, and interact with smart contracts on **Taiko Alethia** (mainnet).
+
+**Features:**
+- Complete Foundry setup with Shanghai EVM configuration
+- Contract deployment and verification guides (Taikoscan, Blockscout, Etherscan V2)
+- Protocol contract addresses for L1 (Ethereum) and L2 (Taiko)
+- Python and Solidity examples
+- Cross-chain messaging patterns
+- x402 payment facilitator integration
+
 ## Plugin Structure
 
 ```
 taiko-ai/
 ├── .claude-plugin/
-│   └── plugin.json            # Plugin manifest
+│   └── plugin.json               # Plugin manifest
 ├── agents/
-│   └── taiko-hoodi-developer.md  # Taiko development subagent
+│   ├── taiko-hoodi-developer.md  # Hoodi testnet subagent
+│   └── taiko-mainnet-developer.md # Mainnet subagent
 ├── skills/
-│   ├── hoodi/                 # /taiko:hoodi skill
-│   │   ├── SKILL.md           # Main skill file
-│   │   ├── references/        # Contract addresses, network config
-│   │   ├── examples/          # Python and Solidity examples
-│   │   └── assets/            # Foundry template
-│   └── shared/                # Network-agnostic protocol docs
-├── mcp-servers/               # MCP server implementations (future)
+│   ├── hoodi/                    # /taiko:hoodi skill
+│   │   ├── SKILL.md              # Main skill file
+│   │   ├── references/           # Contract addresses, network config
+│   │   ├── examples/             # Python and Solidity examples
+│   │   └── assets/               # Foundry template
+│   ├── mainnet/                  # /taiko:mainnet skill
+│   │   ├── SKILL.md              # Main skill file
+│   │   ├── references/           # Contract addresses, network config
+│   │   ├── examples/             # Python and Solidity examples
+│   │   └── assets/               # Foundry template
+│   └── shared/                   # Network-agnostic protocol docs
+├── mcp-servers/                  # MCP server implementations (future)
 └── README.md
 ```
 
 ## Agents
 
-The `taiko-hoodi-developer` agent provides specialized assistance for Taiko development:
-- Smart contract development with security patterns
-- Testing with Foundry (unit, fork, fuzz tests)
-- Deployment and verification workflows
-- Cross-chain messaging patterns
+Two specialized agents provide context-aware assistance:
 
-The agent is automatically activated when working on Taiko-related tasks.
+- **taiko-hoodi-developer** - Testnet development, testing, and experimentation
+- **taiko-mainnet-developer** - Production deployment with extra safety checks
+
+Both agents are automatically activated when working on Taiko-related tasks.
 
 ## Shared Protocol Knowledge
 
@@ -82,6 +99,7 @@ The `skills/shared/` directory contains network-agnostic documentation used by a
 
 | Network | Chain ID | RPC | Explorer |
 |---------|----------|-----|----------|
+| Taiko Alethia | 167000 | https://rpc.mainnet.taiko.xyz | https://taikoscan.io |
 | Taiko Hoodi | 167013 | https://rpc.hoodi.taiko.xyz | https://hoodi.taikoscan.io |
 
 ## Development
@@ -95,7 +113,13 @@ The `skills/shared/` directory contains network-agnostic documentation used by a
 ### Using the Foundry Template
 
 ```bash
+# For testnet
 cd skills/hoodi/assets/foundry-template
+
+# For mainnet
+cd skills/mainnet/assets/foundry-template
+
+# Then:
 cp .env.example .env
 # Edit .env with your private key
 
@@ -105,7 +129,7 @@ forge install
 # Build with Shanghai EVM
 FOUNDRY_PROFILE=layer2 forge build
 
-# Deploy
+# Deploy (testnet example)
 FOUNDRY_PROFILE=layer2 forge create src/Counter.sol:Counter \
   --rpc-url https://rpc.hoodi.taiko.xyz \
   --private-key $PRIVATE_KEY
@@ -119,14 +143,17 @@ claude --plugin-dir ./taiko-ai
 
 # Then use the skills
 /taiko:hoodi
+/taiko:mainnet
 ```
 
 ## Resources
 
 - [Taiko Documentation](https://docs.taiko.xyz)
 - [Taiko GitHub](https://github.com/taikoxyz/taiko-mono)
-- [Bridge UI](https://bridge.hoodi.taiko.xyz)
-- [Block Explorer](https://hoodi.taikoscan.io)
+- [Bridge UI (Mainnet)](https://bridge.taiko.xyz)
+- [Bridge UI (Testnet)](https://bridge.hoodi.taiko.xyz)
+- [Block Explorer (Mainnet)](https://taikoscan.io)
+- [Block Explorer (Testnet)](https://hoodi.taikoscan.io)
 - [Claude Code Plugins](https://code.claude.com/docs/en/plugins)
 
 ## Contributing

--- a/agents/taiko-mainnet-developer.md
+++ b/agents/taiko-mainnet-developer.md
@@ -1,0 +1,94 @@
+---
+name: taiko-mainnet-developer
+description: >
+  Use this agent when developing, testing, or deploying smart contracts
+  on Taiko Alethia mainnet. Triggers: "Taiko mainnet", "Alethia", "mainnet deployment",
+  "production deploy", "mainnet bridge". Use proactively after writing Solidity code for mainnet.
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: sonnet
+color: "#E81899"
+memory: project
+skills:
+  - taiko:mainnet
+---
+
+You are a senior blockchain developer specializing in Taiko network development.
+
+## Critical Rules
+
+1. **ALWAYS use `FOUNDRY_PROFILE=layer2`** for all Foundry commands on Taiko L2
+2. Taiko uses **Shanghai EVM** - no Prague opcodes (PUSH0, MCOPY, TSTORE, TLOAD)
+3. Use `TaikoMainnetAddresses.sol` for protocol addresses
+4. Custom errors > require strings (gas efficiency)
+5. CEI pattern (Checks-Effects-Interactions) for state changes
+6. OpenZeppelin v5 contracts only
+7. **This is mainnet** - double-check all addresses, audit contracts before deployment
+
+## Quick Reference
+
+| Network | Chain ID | RPC | Explorer |
+|---------|----------|-----|----------|
+| Taiko Alethia | 167000 | https://rpc.mainnet.taiko.xyz | https://taikoscan.io |
+| Ethereum Mainnet | 1 | https://eth.drpc.org | https://etherscan.io |
+
+## Workflow
+
+```bash
+# 1. Build
+FOUNDRY_PROFILE=layer2 forge build
+
+# 2. Test
+FOUNDRY_PROFILE=layer2 forge test --fork-url https://rpc.mainnet.taiko.xyz -vvv
+
+# 3. Deploy
+FOUNDRY_PROFILE=layer2 forge script script/Deploy.s.sol:DeployScript \
+  --rpc-url https://rpc.mainnet.taiko.xyz --private-key $PRIVATE_KEY --broadcast
+
+# 4. Verify (Etherscan V2 API)
+forge verify-contract $ADDRESS src/Contract.sol:Contract \
+  --verifier etherscan \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=167000" \
+  --etherscan-api-key $ETHERSCAN_API_KEY --watch
+```
+
+## Key Protocol Addresses
+
+```solidity
+// L2 (Taiko Alethia - 167000)
+L2_BRIDGE         = 0x1670000000000000000000000000000000000001
+L2_SIGNAL_SERVICE = 0x1670000000000000000000000000000000000005
+L2_TAIKO_ANCHOR   = 0x1670000000000000000000000000000000010001
+
+// L1 (Ethereum Mainnet - 1)
+L1_BRIDGE         = 0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC
+L1_SIGNAL_SERVICE = 0x9e0a24964e5397B566c1ed39258e21aB5E35C77C
+```
+
+## Security Checklist
+
+- [ ] CEI pattern + reentrancy guards
+- [ ] Access control (Ownable/AccessControl)
+- [ ] Input validation (zero address, bounds)
+- [ ] Events for state changes
+- [ ] SafeERC20 for token transfers
+- [ ] Bridge callbacks verify `msg.sender == bridge`
+- [ ] Cross-chain: validate `ctx.srcChainId` and `ctx.from`
+- [ ] **Mainnet audit completed before deployment**
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Invalid EVM version | `FOUNDRY_PROFILE=layer2` |
+| PUSH0 not supported | Compile with Shanghai |
+| Verification fails | Use `--watch`, check API key |
+| Insufficient funds | Bridge ETH from L1 Ethereum |
+| Tx reverted | `cast run <TX_HASH>` to debug |
+
+## Resources
+
+Refer to skill docs for details:
+- `shared/protocol-overview.md` - Architecture
+- `shared/cross-chain-patterns.md` - L1↔L2 messaging
+- `shared/bridge-interface.md` - Bridge API
+- `shared/security-checklist.md` - Full security guide

--- a/skills/mainnet/SKILL.md
+++ b/skills/mainnet/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: mainnet
+description: Deploy, test, and interact with smart contracts on Taiko Alethia mainnet using Foundry. Use when "Taiko mainnet", "Taiko Alethia", or "mainnet deployment" is mentioned.
+---
+
+# Taiko Mainnet Development
+
+Build, deploy, and verify smart contracts on Taiko Alethia (mainnet).
+
+## Quick Reference
+
+| Property | Value |
+|----------|-------|
+| Chain ID | `167000` |
+| RPC URL | `https://rpc.mainnet.taiko.xyz` |
+| Currency | ETH |
+| Block Explorer | `https://taikoscan.io` |
+| EVM Version | Shanghai (Type-1 ZK-EVM) |
+| Solidity | `^0.8.24` (protocol uses `0.8.30`) |
+| x402 Facilitators | `https://facilitator.taiko.xyz`, `https://x402.taiko.xyz` |
+
+## Quick Decision Guide
+
+| Task | Command/Resource |
+|------|------------------|
+| Deploy contract | `FOUNDRY_PROFILE=layer2 forge create ...` |
+| Verify on Taikoscan | `forge verify-contract ...` |
+| Verify on Blockscout | `forge verify-contract --verifier blockscout ...` |
+| Bridge assets | https://bridge.taiko.xyz |
+| Fork testing | `FOUNDRY_PROFILE=layer2 forge test --fork-url ...` |
+
+## Shared Protocol Knowledge
+
+Before deploying, review these shared resources:
+
+- [Protocol Overview](../shared/protocol-overview.md) - Based rollup architecture
+- [EVM Compatibility](../shared/evm-compatibility.md) - Shanghai EVM details
+- [Foundry Guide](../shared/foundry-guide.md) - Complete Foundry setup
+- [Security Checklist](../shared/security-checklist.md) - Pre-deployment checks
+- [Bridge Interface](../shared/bridge-interface.md) - Cross-chain messaging
+- [Cross-Chain Patterns](../shared/cross-chain-patterns.md) - L1↔L2 patterns
+
+## Network-Specific References
+
+- [Contract Addresses](./references/contract-addresses.md) - L1/L2 protocol addresses
+- [Network Configuration](./references/network-config.md) - RPC, gas, explorers
+
+## Foundry Setup
+
+Use `assets/foundry-template/` as a starting point.
+
+**Critical:** Always use `FOUNDRY_PROFILE=layer2` for Taiko L2:
+
+```bash
+# Build with Shanghai EVM
+FOUNDRY_PROFILE=layer2 forge build
+
+# Test with fork
+FOUNDRY_PROFILE=layer2 forge test --fork-url https://rpc.mainnet.taiko.xyz
+```
+
+### foundry.toml Configuration
+
+```toml
+[profile.default]
+solc_version = "0.8.30"
+evm_version = "prague"
+
+# Use for Taiko L2
+[profile.layer2]
+evm_version = "shanghai"
+
+[rpc_endpoints]
+taiko-mainnet = "https://rpc.mainnet.taiko.xyz"
+
+[etherscan]
+taiko-mainnet = { key = "${TAIKOSCAN_API_KEY}", url = "https://api.taikoscan.io/api", chain = 167000 }
+```
+
+## Deploy Commands
+
+### Basic Deployment
+
+```bash
+FOUNDRY_PROFILE=layer2 forge create src/MyContract.sol:MyContract \
+  --rpc-url https://rpc.mainnet.taiko.xyz \
+  --private-key $PRIVATE_KEY
+```
+
+### With Constructor Arguments
+
+```bash
+FOUNDRY_PROFILE=layer2 forge create src/Token.sol:Token \
+  --rpc-url https://rpc.mainnet.taiko.xyz \
+  --private-key $PRIVATE_KEY \
+  --constructor-args "TokenName" "TKN" 1000000000000000000000000
+```
+
+### Using Scripts
+
+```bash
+FOUNDRY_PROFILE=layer2 forge script script/Deploy.s.sol:DeployScript \
+  --rpc-url https://rpc.mainnet.taiko.xyz \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+```
+
+## Verify Commands
+
+### Taikoscan
+
+```bash
+forge verify-contract <CONTRACT_ADDRESS> src/MyContract.sol:MyContract \
+  --watch \
+  --verifier-url https://api.taikoscan.io/api \
+  --etherscan-api-key $TAIKOSCAN_API_KEY
+```
+
+### Blockscout
+
+```bash
+forge verify-contract <CONTRACT_ADDRESS> src/MyContract.sol:MyContract \
+  --chain-id 167000 \
+  --verifier blockscout \
+  --verifier-url https://blockscoutapi.mainnet.taiko.xyz/api?
+```
+
+### Etherscan V2 (Unified API)
+
+```bash
+forge verify-contract <CONTRACT_ADDRESS> src/MyContract.sol:MyContract \
+  --verifier etherscan \
+  --verifier-url "https://api.etherscan.io/v2/api?chainid=167000" \
+  --etherscan-api-key $ETHERSCAN_API_KEY --watch
+```
+
+## Testing on Taiko
+
+```bash
+# Fork Taiko mainnet for testing
+FOUNDRY_PROFILE=layer2 forge test --fork-url https://rpc.mainnet.taiko.xyz
+
+# Run specific test with fork
+FOUNDRY_PROFILE=layer2 forge test --match-test testBridgeInteraction --fork-url https://rpc.mainnet.taiko.xyz -vvv
+
+# Gas report
+FOUNDRY_PROFILE=layer2 forge test --gas-report --fork-url https://rpc.mainnet.taiko.xyz
+```
+
+## Bridging Assets
+
+To deploy contracts, you need ETH on Taiko Alethia:
+
+1. **Get ETH on Ethereum Mainnet** - Purchase from an exchange or use an existing wallet
+2. **Bridge to Taiko Alethia** - https://bridge.taiko.xyz
+
+**Note:** Bridging back to L1 takes up to 24 hours due to the cooldown period.
+
+## Cast CLI Commands
+
+```bash
+# Check ETH balance
+cast balance <ADDRESS> --rpc-url https://rpc.mainnet.taiko.xyz
+
+# Get chain ID
+cast chain-id --rpc-url https://rpc.mainnet.taiko.xyz
+
+# Get block number
+cast block-number --rpc-url https://rpc.mainnet.taiko.xyz
+
+# Get gas price
+cast gas-price --rpc-url https://rpc.mainnet.taiko.xyz
+
+# Send transaction
+cast send <TO> "functionName(args)" --rpc-url https://rpc.mainnet.taiko.xyz --private-key $PRIVATE_KEY
+```
+
+## Examples
+
+See `examples/` directory for:
+- **Python**: Block hash calculation, signal verification
+- **Solidity**: Bridge receiver, cross-chain contracts
+
+## Useful Tools
+
+- **Code Diff**: https://codediff.taiko.xyz - Compare contract implementations
+- **Status Page**: https://status.taiko.xyz - Network status
+- **Proof Dashboard**: https://proofs.taiko.xyz - ZK proof coverage
+
+## x402 Payments
+
+Taiko runs [x402](https://www.x402.org) facilitators for HTTP-native payments. Both use scheme `exact`, x402 version `2`, and expose endpoints: `POST /verify`, `POST /settle`, `GET /supported`.
+
+### facilitator.taiko.xyz (Hoodi + Mainnet)
+
+| Property | Value |
+|----------|-------|
+| URL | `https://facilitator.taiko.xyz` |
+| Networks | `eip155:167013` (Hoodi), `eip155:167000` (Mainnet) |
+| Signer (Hoodi) | `0x81062a8b93fc840225bf879829145e3840057CD4` |
+| Signer (Mainnet) | `0x368F2B55172DFABcEa49A88508237B73C78Ed2f2` |
+
+### x402.taiko.xyz (Mainnet only)
+
+| Property | Value |
+|----------|-------|
+| URL | `https://x402.taiko.xyz` |
+| Network | `eip155:167000` (Mainnet) |
+| Signer | `0x2A67c750b770878196d258cEc987Bd530caFfBf7` |
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Invalid EVM version" | Use `FOUNDRY_PROFILE=layer2` |
+| "Contract not verified" | Check API endpoint URL and key |
+| "Insufficient funds" | Bridge ETH from L1 Ethereum |
+| "Transaction reverted" | Use `cast run <TX_HASH>` to debug |
+| Build fails with PUSH0 | Ensure using Shanghai EVM |
+
+## Protocol Source
+
+- Latest releases: https://github.com/taikoxyz/taiko-mono/releases?q=alethia-protocol
+- Protocol source: https://github.com/taikoxyz/taiko-mono/tree/main/packages/protocol

--- a/skills/mainnet/assets/foundry-template/.env.example
+++ b/skills/mainnet/assets/foundry-template/.env.example
@@ -1,0 +1,13 @@
+# Private key for deployment (without 0x prefix)
+PRIVATE_KEY=
+
+# RPC URLs
+TAIKO_RPC=https://rpc.mainnet.taiko.xyz
+ETH_RPC_URL=
+
+# API Keys for verification
+TAIKOSCAN_API_KEY=
+ETHERSCAN_API_KEY=
+
+# Deployment addresses (optional)
+DEPLOYER_ADDRESS=

--- a/skills/mainnet/assets/foundry-template/.gitignore
+++ b/skills/mainnet/assets/foundry-template/.gitignore
@@ -1,0 +1,12 @@
+# Dependencies
+lib/
+
+# Build artifacts
+out/
+cache/
+
+# Environment
+.env
+
+# OS files
+.DS_Store

--- a/skills/mainnet/assets/foundry-template/README.md
+++ b/skills/mainnet/assets/foundry-template/README.md
@@ -1,0 +1,143 @@
+# Taiko Mainnet Foundry Template
+
+A ready-to-use Foundry project for deploying smart contracts on Taiko Alethia (mainnet).
+
+## Quick Start
+
+```bash
+# Install dependencies
+forge install foundry-rs/forge-std
+forge install OpenZeppelin/openzeppelin-contracts@v5.0.0
+forge install OpenZeppelin/openzeppelin-contracts-upgradeable@v5.0.0
+
+# Copy environment file
+cp .env.example .env
+# Edit .env with your private key
+
+# Build (use layer2 profile for Taiko)
+FOUNDRY_PROFILE=layer2 forge build
+
+# Test
+FOUNDRY_PROFILE=layer2 forge test
+
+# Deploy
+FOUNDRY_PROFILE=layer2 forge script script/Deploy.s.sol:DeployCounter \
+  --rpc-url https://rpc.mainnet.taiko.xyz \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+```
+
+## Important: EVM Version
+
+Taiko uses **Shanghai EVM**. Always use `FOUNDRY_PROFILE=layer2` when building or deploying to Taiko L2.
+
+```bash
+# Correct
+FOUNDRY_PROFILE=layer2 forge build
+
+# Wrong - will use Prague EVM
+forge build
+```
+
+## Project Structure
+
+```
+├── src/
+│   ├── Counter.sol                # Example contract
+│   └── TaikoMainnetAddresses.sol  # Protocol address constants
+├── script/
+│   └── Deploy.s.sol               # Deployment scripts
+├── test/
+│   └── Counter.t.sol              # Tests including fork tests
+├── foundry.toml                   # Foundry configuration
+├── remappings.txt                 # Import remappings for OpenZeppelin
+└── .env.example                   # Environment template
+```
+
+## Using OpenZeppelin
+
+This template is pre-configured for OpenZeppelin v5. Import contracts with:
+
+```solidity
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+```
+
+For upgradeable contracts:
+
+```solidity
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+```
+
+**Important:** Never use `forge update` without specifying a version tag, as it defaults to the unstable master branch.
+
+## Deploying Contracts
+
+### Using forge create
+
+```bash
+FOUNDRY_PROFILE=layer2 forge create src/Counter.sol:Counter \
+  --rpc-url https://rpc.mainnet.taiko.xyz \
+  --private-key $PRIVATE_KEY
+```
+
+### Using Scripts
+
+```bash
+FOUNDRY_PROFILE=layer2 forge script script/Deploy.s.sol:DeployCounter \
+  --rpc-url https://rpc.mainnet.taiko.xyz \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+```
+
+## Verifying Contracts
+
+### Taikoscan
+
+```bash
+forge verify-contract <ADDRESS> src/Counter.sol:Counter \
+  --verifier-url https://api.taikoscan.io/api \
+  --etherscan-api-key $TAIKOSCAN_API_KEY
+```
+
+### Blockscout
+
+```bash
+forge verify-contract <ADDRESS> src/Counter.sol:Counter \
+  --chain-id 167000 \
+  --verifier blockscout \
+  --verifier-url "https://blockscoutapi.mainnet.taiko.xyz/api?"
+```
+
+## Fork Testing
+
+Test against live Taiko state:
+
+```bash
+FOUNDRY_PROFILE=layer2 forge test --fork-url https://rpc.mainnet.taiko.xyz -vvv
+```
+
+## Using Protocol Addresses
+
+Import `TaikoMainnetAddresses` for protocol contract addresses:
+
+```solidity
+import {TaikoMainnetAddresses} from "./TaikoMainnetAddresses.sol";
+
+contract MyContract {
+    function getBridge() external pure returns (address) {
+        return TaikoMainnetAddresses.L2_BRIDGE;
+    }
+}
+```
+
+## Getting ETH
+
+1. Acquire ETH on Ethereum Mainnet
+2. Bridge to Taiko via https://bridge.taiko.xyz
+
+## Resources
+
+- [Taiko Docs](https://docs.taiko.xyz)
+- [Foundry Book](https://book.getfoundry.sh)
+- [Block Explorer](https://taikoscan.io)

--- a/skills/mainnet/assets/foundry-template/foundry.toml
+++ b/skills/mainnet/assets/foundry-template/foundry.toml
@@ -1,0 +1,39 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.30"
+evm_version = "prague"
+optimizer = true
+optimizer_runs = 200
+via_ir = false
+
+# Use FOUNDRY_PROFILE=layer2 when compiling or deploying to Taiko L2
+[profile.layer2]
+evm_version = "shanghai"
+
+# Required for OpenZeppelin Upgrades plugin
+ffi = true
+ast = true
+build_info = true
+extra_output = ["storageLayout"]
+
+[rpc_endpoints]
+taiko-mainnet = "https://rpc.mainnet.taiko.xyz"
+ethereum-mainnet = "${ETH_RPC_URL}"
+
+[etherscan]
+taiko-mainnet = { key = "${TAIKOSCAN_API_KEY}", url = "https://api.taikoscan.io/api", chain = 167000 }
+ethereum-mainnet = { key = "${ETHERSCAN_API_KEY}", chain = 1 }
+
+[fmt]
+line_length = 100
+tab_width = 4
+bracket_spacing = true
+
+[fuzz]
+runs = 200
+
+[invariant]
+runs = 256
+depth = 15

--- a/skills/mainnet/assets/foundry-template/remappings.txt
+++ b/skills/mainnet/assets/foundry-template/remappings.txt
@@ -1,0 +1,3 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
+forge-std/=lib/forge-std/src/

--- a/skills/mainnet/assets/foundry-template/script/Deploy.s.sol
+++ b/skills/mainnet/assets/foundry-template/script/Deploy.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console} from "forge-std/Script.sol";
+import {Counter} from "../src/Counter.sol";
+import {TaikoMainnetAddresses} from "../src/TaikoMainnetAddresses.sol";
+
+/// @title DeployCounter
+/// @notice Deployment script for Counter contract on Taiko Alethia mainnet
+contract DeployCounter is Script {
+    function setUp() public {}
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        Counter counter = new Counter();
+        console.log("Counter deployed to:", address(counter));
+
+        // Optionally set initial value
+        counter.setNumber(0);
+
+        vm.stopBroadcast();
+    }
+}
+
+/// @title DeployToTaiko
+/// @notice Helper script with Taiko-specific configuration and validation
+contract DeployToTaiko is Script {
+    function run() public {
+        // Verify we're on Taiko Alethia mainnet
+        require(
+            block.chainid == TaikoMainnetAddresses.TAIKO_MAINNET_CHAIN_ID,
+            "Not on Taiko Alethia mainnet"
+        );
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Deploy your contracts here
+        Counter counter = new Counter();
+        console.log("Counter deployed to:", address(counter));
+
+        vm.stopBroadcast();
+
+        // Log deployment info
+        console.log("Chain ID:", block.chainid);
+        console.log("Block number:", block.number);
+        console.log("Bridge address:", TaikoMainnetAddresses.L2_BRIDGE);
+    }
+}

--- a/skills/mainnet/assets/foundry-template/src/Counter.sol
+++ b/skills/mainnet/assets/foundry-template/src/Counter.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title Counter
+/// @notice A simple counter contract for testing deployments on Taiko
+contract Counter {
+    uint256 public number;
+
+    event NumberSet(uint256 indexed oldNumber, uint256 indexed newNumber);
+
+    /// @notice Set the counter to a specific number
+    /// @param newNumber The new value for the counter
+    function setNumber(uint256 newNumber) public {
+        uint256 oldNumber = number;
+        number = newNumber;
+        emit NumberSet(oldNumber, newNumber);
+    }
+
+    /// @notice Increment the counter by 1
+    function increment() public {
+        number++;
+    }
+
+    /// @notice Decrement the counter by 1
+    function decrement() public {
+        require(number > 0, "Counter: cannot decrement below zero");
+        number--;
+    }
+}

--- a/skills/mainnet/assets/foundry-template/src/TaikoMainnetAddresses.sol
+++ b/skills/mainnet/assets/foundry-template/src/TaikoMainnetAddresses.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title TaikoMainnetAddresses
+/// @notice Protocol addresses for Taiko Alethia (mainnet) and Ethereum Mainnet (L1)
+/// @dev Source: mainnet-contract-logs-L1.md / mainnet-contract-logs-L2.md
+///      Full list: see ../../references/contract-addresses.md
+library TaikoMainnetAddresses {
+    // ============ Taiko L2 (Chain ID: 167000) ============
+
+    address internal constant L2_BRIDGE = 0x1670000000000000000000000000000000000001;
+    address internal constant L2_ERC20_VAULT = 0x1670000000000000000000000000000000000002;
+    address internal constant L2_ERC721_VAULT = 0x1670000000000000000000000000000000000003;
+    address internal constant L2_ERC1155_VAULT = 0x1670000000000000000000000000000000000004;
+    address internal constant L2_SIGNAL_SERVICE = 0x1670000000000000000000000000000000000005;
+    address internal constant L2_SHARED_RESOLVER = 0x1670000000000000000000000000000000000006;
+    address internal constant L2_TAIKO_ANCHOR = 0x1670000000000000000000000000000000010001;
+    address internal constant L2_ROLLUP_RESOLVER = 0x1670000000000000000000000000000000010002;
+    address internal constant L2_TAIKO_TOKEN = 0xA9d23408b9bA935c230493c40C73824Df71A0975;
+    address internal constant L2_DELEGATE_CONTROLLER = 0xfA06E15B8b4c5BF3FC5d9cfD083d45c53Cbe8C7C;
+
+    // ============ Ethereum Mainnet L1 (Chain ID: 1) ============
+
+    address internal constant L1_INBOX = 0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a;
+    address internal constant L1_FORCED_INCLUSION_STORE = 0x05d88855361808fA1d7fc28084Ef3fCa191c4e03;
+    address internal constant L1_TAIKO_TOKEN = 0x10dea67478c5F8C5E2D90e5E9B26dBe60c54d800;
+    address internal constant L1_BRIDGE = 0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC;
+    address internal constant L1_SIGNAL_SERVICE = 0x9e0a24964e5397B566c1ed39258e21aB5E35C77C;
+    address internal constant L1_ERC20_VAULT = 0x996282cA11E5DEb6B5D122CC3B9A1FcAAD4415Ab;
+    address internal constant L1_ERC721_VAULT = 0x0b470dd3A0e1C41228856Fb319649E7c08f419Aa;
+    address internal constant L1_ERC1155_VAULT = 0xaf145913EA4a56BE22E120ED9C24589659881702;
+    address internal constant L1_PRECONF_WHITELIST = 0xFD019460881e6EeC632258222393d5821029b2ac;
+    address internal constant L1_SHARED_RESOLVER = 0x8Efa01564425692d0a0838DC10E300BD310Cb43e;
+
+    // ============ Chain IDs ============
+
+    uint64 internal constant TAIKO_MAINNET_CHAIN_ID = 167_000;
+    uint64 internal constant ETHEREUM_MAINNET_CHAIN_ID = 1;
+}

--- a/skills/mainnet/assets/foundry-template/test/Counter.t.sol
+++ b/skills/mainnet/assets/foundry-template/test/Counter.t.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Counter} from "../src/Counter.sol";
+import {TaikoMainnetAddresses} from "../src/TaikoMainnetAddresses.sol";
+
+/// @title CounterTest
+/// @notice Tests for Counter contract
+/// @dev Run with: FOUNDRY_PROFILE=layer2 forge test
+///      Fork test: FOUNDRY_PROFILE=layer2 forge test --fork-url https://rpc.mainnet.taiko.xyz
+contract CounterTest is Test {
+    Counter public counter;
+
+    function setUp() public {
+        counter = new Counter();
+    }
+
+    function test_InitialValue() public view {
+        assertEq(counter.number(), 0);
+    }
+
+    function test_SetNumber() public {
+        counter.setNumber(42);
+        assertEq(counter.number(), 42);
+    }
+
+    function test_Increment() public {
+        counter.setNumber(10);
+        counter.increment();
+        assertEq(counter.number(), 11);
+    }
+
+    function test_Decrement() public {
+        counter.setNumber(10);
+        counter.decrement();
+        assertEq(counter.number(), 9);
+    }
+
+    function test_RevertWhen_DecrementBelowZero() public {
+        counter.setNumber(0);
+        vm.expectRevert("Counter: cannot decrement below zero");
+        counter.decrement();
+    }
+
+    function testFuzz_SetNumber(uint256 x) public {
+        counter.setNumber(x);
+        assertEq(counter.number(), x);
+    }
+}
+
+/// @title TaikoForkTest
+/// @notice Tests that interact with Taiko protocol contracts
+/// @dev Run with: FOUNDRY_PROFILE=layer2 forge test --fork-url https://rpc.mainnet.taiko.xyz
+contract TaikoForkTest is Test {
+    function test_BridgeExists() public view {
+        // Skip if not running on fork
+        if (block.chainid != TaikoMainnetAddresses.TAIKO_MAINNET_CHAIN_ID) {
+            return;
+        }
+
+        // Verify bridge contract has code
+        address bridge = TaikoMainnetAddresses.L2_BRIDGE;
+        uint256 codeSize;
+        assembly {
+            codeSize := extcodesize(bridge)
+        }
+        assertGt(codeSize, 0, "Bridge should have code");
+    }
+
+    function test_SignalServiceExists() public view {
+        // Skip if not running on fork
+        if (block.chainid != TaikoMainnetAddresses.TAIKO_MAINNET_CHAIN_ID) {
+            return;
+        }
+
+        // Verify signal service contract has code
+        address signalService = TaikoMainnetAddresses.L2_SIGNAL_SERVICE;
+        uint256 codeSize;
+        assembly {
+            codeSize := extcodesize(signalService)
+        }
+        assertGt(codeSize, 0, "SignalService should have code");
+    }
+}

--- a/skills/mainnet/examples/python/README.md
+++ b/skills/mainnet/examples/python/README.md
@@ -1,0 +1,28 @@
+# Python Examples
+
+Utilities for Taiko Alethia mainnet. Falls back to Foundry's `cast` if dependencies unavailable.
+
+## calc_blockhash.py
+
+Calculate and verify block hashes via RLP encoding + keccak256.
+
+```bash
+python calc_blockhash.py
+# Output: Block number, RPC hash, computed hash, match status
+```
+
+## verify_signal.py
+
+Verify signals using merkle proofs via `eth_getProof`.
+
+```bash
+python verify_signal.py
+```
+
+## Setup
+
+```bash
+pip install -r requirements.txt  # Optional - scripts use cast fallback
+```
+
+RPC: `https://rpc.mainnet.taiko.xyz`

--- a/skills/mainnet/examples/python/calc_blockhash.py
+++ b/skills/mainnet/examples/python/calc_blockhash.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Utility to compare Taiko Alethia mainnet RPC block.hash vs keccak256(RLP(header)).
+Shanghai-only header encoding for Alethia/Shasta.
+
+Optional dependency: pip install pysha3
+Fallback hashing path: `cast keccak` if `pysha3` is unavailable.
+"""
+
+import json
+import subprocess
+from typing import Union
+import urllib.request
+
+RPC = "https://rpc.mainnet.taiko.xyz"
+BLOCK_HEX = "0x1E8480"  # 2000000
+
+try:
+    from sha3 import keccak_256  # type: ignore
+except ImportError:
+    keccak_256 = None
+
+
+def qty_to_int(value: str) -> int:
+    """Parse an RPC quantity (0x-prefixed) into an integer."""
+    if not isinstance(value, str) or not value.startswith("0x"):
+        raise TypeError(f"Expected quantity hex string, got: {value!r}")
+    return int(value, 16)
+
+
+def hex_bytes(value: str) -> bytes:
+    """Parse hex data (0x-prefixed) into bytes."""
+    if not isinstance(value, str) or not value.startswith("0x"):
+        raise TypeError(f"Expected data hex string, got: {value!r}")
+    body = value[2:]
+    if len(body) % 2 == 1:
+        body = "0" + body
+    return bytes.fromhex(body) if body else b""
+
+
+def int_to_min_bytes(value: int) -> bytes:
+    """Convert integer to minimal big-endian bytes; zero maps to empty bytes."""
+    if value < 0:
+        raise ValueError("RLP integer cannot be negative")
+    if value == 0:
+        return b""
+    out = bytearray()
+    while value:
+        out.append(value & 0xFF)
+        value >>= 8
+    return bytes(reversed(out))
+
+
+def enc_len(length: int, offset: int) -> bytes:
+    """Encode RLP length prefix for string/list payloads."""
+    if length < 56:
+        return bytes([length + offset])
+    len_bytes = int_to_min_bytes(length)
+    return bytes([len(len_bytes) + offset + 55]) + len_bytes
+
+
+def rlp(item: Union[int, bytes, list]) -> bytes:
+    """RLP-encode integers, bytes, or lists of encodable items."""
+    if isinstance(item, list):
+        payload = b"".join(rlp(x) for x in item)
+        return enc_len(len(payload), 0xC0) + payload
+
+    if isinstance(item, int):
+        payload = int_to_min_bytes(item)
+    elif isinstance(item, bytes):
+        payload = item
+    else:
+        raise TypeError(f"Unsupported RLP item type: {type(item)}")
+
+    if len(payload) == 1 and payload[0] < 0x80:
+        return payload
+    return enc_len(len(payload), 0x80) + payload
+
+
+def keccak256_hex(payload: bytes) -> str:
+    """Compute Keccak-256 and return 0x-prefixed hex."""
+    if keccak_256 is not None:
+        return "0x" + keccak_256(payload).hexdigest()
+
+    try:
+        out = subprocess.check_output(
+            ["cast", "keccak", "0x" + payload.hex()],
+            text=True,
+        ).strip()
+    except FileNotFoundError as exc:
+        raise SystemExit(
+            "pysha3 is not installed and `cast` was not found. "
+            "Install pysha3 (`pip install pysha3`) or Foundry cast."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f"Failed to compute keccak via cast: {exc}") from exc
+
+    return out if out.startswith("0x") else "0x" + out
+
+
+def require_field(block: dict, key: str) -> str:
+    """Fetch a required header key and fail fast if absent."""
+    value = block.get(key)
+    if value is None:
+        raise SystemExit(f"Missing required Shanghai header field: {key}")
+    return value
+
+
+def shanghai_header_fields(block: dict) -> list:
+    """Return Shanghai header fields in canonical hash order."""
+    return [
+        hex_bytes(require_field(block, "parentHash")),
+        hex_bytes(require_field(block, "sha3Uncles")),
+        hex_bytes(require_field(block, "miner")),
+        hex_bytes(require_field(block, "stateRoot")),
+        hex_bytes(require_field(block, "transactionsRoot")),
+        hex_bytes(require_field(block, "receiptsRoot")),
+        hex_bytes(require_field(block, "logsBloom")),
+        qty_to_int(require_field(block, "difficulty")),
+        qty_to_int(require_field(block, "number")),
+        qty_to_int(require_field(block, "gasLimit")),
+        qty_to_int(require_field(block, "gasUsed")),
+        qty_to_int(require_field(block, "timestamp")),
+        hex_bytes(require_field(block, "extraData")),
+        hex_bytes(require_field(block, "mixHash")),
+        hex_bytes(require_field(block, "nonce")),
+        qty_to_int(require_field(block, "baseFeePerGas")),
+        hex_bytes(require_field(block, "withdrawalsRoot")),
+    ]
+
+
+def main() -> None:
+    """Load a mainnet header and compare RPC hash to local header-hash computation."""
+    req = urllib.request.Request(
+        RPC,
+        data=json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "eth_getHeaderByNumber",
+                "params": [BLOCK_HEX],
+                "id": 1,
+            }
+        ).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        data = json.loads(resp.read())
+
+    block = data.get("result")
+    if not block:
+        raise SystemExit(f"Block {BLOCK_HEX} not found")
+
+    fields = shanghai_header_fields(block)
+    header_rlp = rlp(fields)
+    computed = keccak256_hex(header_rlp).lower()
+    rpc_hash = require_field(block, "hash").lower()
+
+    print("Block number:", int(require_field(block, "number"), 16))
+    print("RPC block.hash:", rpc_hash)
+    print("keccak(headerRlp):", computed)
+    if rpc_hash != computed:
+        print(">>> mismatch detected <<<")
+    else:
+        print("hash matches header keccak")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/mainnet/examples/python/requirements.txt
+++ b/skills/mainnet/examples/python/requirements.txt
@@ -1,0 +1,8 @@
+# Core dependencies
+# Note: pysha3 is optional - scripts fall back to `cast keccak` if unavailable
+
+# Optional: For native keccak256 support
+pysha3>=1.0.0
+
+# Optional: For more advanced web3 interactions
+# web3>=6.0.0

--- a/skills/mainnet/examples/python/verify_signal.py
+++ b/skills/mainnet/examples/python/verify_signal.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Example: Verify a signal was sent on Taiko Alethia mainnet using merkle proofs.
+
+This demonstrates how to:
+1. Query the SignalService for a signal slot
+2. Generate a storage proof using eth_getProof
+3. Verify the proof locally
+
+Dependencies: pip install web3
+"""
+
+import json
+from typing import Optional
+import urllib.request
+
+# Taiko Alethia mainnet configuration
+RPC = "https://rpc.mainnet.taiko.xyz"
+CHAIN_ID = 167000
+
+# SignalService address on Taiko Alethia L2
+SIGNAL_SERVICE = "0x1670000000000000000000000000000000000005"
+
+
+def rpc_call(method: str, params: list) -> dict:
+    """Make a JSON-RPC call to the Taiko Alethia RPC."""
+    req = urllib.request.Request(
+        RPC,
+        data=json.dumps({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1,
+        }).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+
+    if "error" in data:
+        raise Exception(f"RPC error: {data['error']}")
+
+    return data.get("result")
+
+
+def keccak256(data: bytes) -> bytes:
+    """Compute keccak256 hash. Requires pysha3 or falls back to cast."""
+    try:
+        from sha3 import keccak_256
+        return keccak_256(data).digest()
+    except ImportError:
+        import subprocess
+        hex_data = "0x" + data.hex()
+        result = subprocess.check_output(["cast", "keccak", hex_data], text=True).strip()
+        return bytes.fromhex(result[2:])
+
+
+def compute_signal_slot(chain_id: int, app: str, signal: bytes) -> bytes:
+    """
+    Compute the storage slot for a signal.
+
+    slot = keccak256(abi.encodePacked("SIGNAL", chainId, app, signal))
+    """
+    # Encode: "SIGNAL" + uint64(chainId) + address(app) + bytes32(signal)
+    encoded = b"SIGNAL"
+    encoded += chain_id.to_bytes(8, "big")
+    encoded += bytes.fromhex(app[2:].lower().zfill(40))
+    encoded += signal
+
+    return keccak256(encoded)
+
+
+def get_storage_proof(
+    contract: str,
+    slot: bytes,
+    block: str = "latest"
+) -> Optional[dict]:
+    """
+    Get a merkle proof for a storage slot.
+
+    Returns the proof data from eth_getProof.
+    """
+    slot_hex = "0x" + slot.hex()
+
+    result = rpc_call("eth_getProof", [contract, [slot_hex], block])
+
+    if not result or not result.get("storageProof"):
+        return None
+
+    return result
+
+
+def verify_signal_sent(
+    chain_id: int,
+    sender_app: str,
+    signal: bytes,
+    block: str = "latest"
+) -> bool:
+    """
+    Verify that a signal was sent by checking storage.
+
+    Args:
+        chain_id: The chain ID where the signal was sent
+        sender_app: The contract that sent the signal
+        signal: The 32-byte signal value
+        block: Block number or "latest"
+
+    Returns:
+        True if the signal exists in storage
+    """
+    # Compute the storage slot
+    slot = compute_signal_slot(chain_id, sender_app, signal)
+    print(f"Signal slot: 0x{slot.hex()}")
+
+    # Get the storage proof
+    proof = get_storage_proof(SIGNAL_SERVICE, slot, block)
+
+    if not proof:
+        print("Failed to get storage proof")
+        return False
+
+    # Check the storage value
+    storage_proof = proof["storageProof"][0]
+    value = storage_proof.get("value", "0x0")
+
+    print(f"Storage value: {value}")
+    print(f"Account proof length: {len(proof.get('accountProof', []))}")
+    print(f"Storage proof length: {len(storage_proof.get('proof', []))}")
+
+    # Signal exists if value matches the signal
+    expected = "0x" + signal.hex()
+    return value.lower() == expected.lower()
+
+
+def main():
+    """Example: Check if a specific signal exists."""
+    print("Signal Verification Example for Taiko Alethia Mainnet")
+    print("=" * 55)
+    print(f"RPC: {RPC}")
+    print(f"Chain ID: {CHAIN_ID}")
+    print(f"SignalService: {SIGNAL_SERVICE}")
+    print()
+
+    # Example signal (you would replace this with an actual signal)
+    # In practice, this would be a message hash from the Bridge
+    example_signal = bytes.fromhex(
+        "0000000000000000000000000000000000000000000000000000000000000001"
+    )
+
+    # Example sender (Bridge contract)
+    bridge_address = "0x1670000000000000000000000000000000000001"
+
+    print(f"Checking signal from: {bridge_address}")
+    print(f"Signal: 0x{example_signal.hex()}")
+    print()
+
+    # This will likely return False unless the signal actually exists
+    exists = verify_signal_sent(
+        chain_id=CHAIN_ID,
+        sender_app=bridge_address,
+        signal=example_signal,
+    )
+
+    print()
+    if exists:
+        print("Signal EXISTS in storage")
+    else:
+        print("Signal NOT FOUND (expected for example data)")
+
+    print()
+    print("To verify a real signal:")
+    print("1. Get a message hash from a Bridge MessageSent event")
+    print("2. Use the sender contract address")
+    print("3. Call verify_signal_sent() with the actual values")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/mainnet/examples/solidity/BridgeReceiver.sol
+++ b/skills/mainnet/examples/solidity/BridgeReceiver.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IBridge
+/// @notice Minimal interface for Taiko Bridge message receiving
+interface IBridge {
+    struct Message {
+        uint64 id;
+        uint64 fee;
+        uint32 gasLimit;
+        address from;
+        uint64 srcChainId;
+        address srcOwner;
+        uint64 destChainId;
+        address destOwner;
+        address to;
+        uint256 value;
+        bytes data;
+    }
+
+    struct Context {
+        bytes32 msgHash;
+        address from;
+        uint64 srcChainId;
+    }
+
+    function context() external view returns (Context memory);
+}
+
+/// @title BridgeReceiver
+/// @notice Example contract demonstrating how to receive cross-chain messages on Taiko
+/// @dev This contract can be called by the Bridge when processing messages from L1
+///
+/// Usage:
+/// 1. Deploy this contract on Taiko L2
+/// 2. From L1, send a bridge message with this contract as the `to` address
+/// 3. The bridge will call `onMessageReceived` with the message data
+///
+/// Build with: FOUNDRY_PROFILE=layer2 forge build
+contract BridgeReceiver {
+    // Taiko Alethia Bridge address
+    address public constant BRIDGE = 0x1670000000000000000000000000000000000001;
+
+    // Events for tracking received messages
+    event MessageReceived(
+        address indexed from,
+        uint64 indexed srcChainId,
+        bytes32 msgHash,
+        bytes data
+    );
+
+    event ValueReceived(
+        address indexed from,
+        uint256 value
+    );
+
+    // Storage for received messages
+    mapping(bytes32 => bool) public processedMessages;
+    uint256 public messageCount;
+    uint256 public totalValueReceived;
+
+    /// @notice Modifier to ensure caller is the bridge
+    modifier onlyBridge() {
+        require(msg.sender == BRIDGE, "BridgeReceiver: caller is not bridge");
+        _;
+    }
+
+    /// @notice Called by the bridge when a message is received
+    /// @param _data The message data sent from the source chain
+    /// @dev Override this function to implement custom message handling
+    function onMessageReceived(bytes calldata _data) external payable onlyBridge {
+        // Get the message context from the bridge
+        IBridge.Context memory ctx = IBridge(BRIDGE).context();
+
+        // Verify message hasn't been processed (replay protection)
+        require(!processedMessages[ctx.msgHash], "BridgeReceiver: message already processed");
+
+        // Mark as processed
+        processedMessages[ctx.msgHash] = true;
+        messageCount++;
+
+        // Track any ETH sent with the message
+        if (msg.value > 0) {
+            totalValueReceived += msg.value;
+            emit ValueReceived(ctx.from, msg.value);
+        }
+
+        // Emit event for off-chain tracking
+        emit MessageReceived(ctx.from, ctx.srcChainId, ctx.msgHash, _data);
+
+        // Process the message data
+        _processMessage(ctx.from, ctx.srcChainId, _data);
+    }
+
+    /// @notice Internal function to process message data
+    /// @param _from The sender address on the source chain
+    /// @param _srcChainId The source chain ID
+    /// @param _data The message data
+    /// @dev Override this in derived contracts for custom logic
+    function _processMessage(
+        address _from,
+        uint64 _srcChainId,
+        bytes calldata _data
+    ) internal virtual {
+        // Default implementation: decode and store the message
+        // Derived contracts can override this for custom handling
+
+        // Example: if data is an address, you could whitelist it
+        // Example: if data is a uint256, you could update state
+        // Example: if data is encoded function call, you could execute it
+    }
+
+    /// @notice Check if a message has been processed
+    /// @param _msgHash The message hash to check
+    /// @return True if the message has been processed
+    function isProcessed(bytes32 _msgHash) external view returns (bool) {
+        return processedMessages[_msgHash];
+    }
+
+    /// @notice Allow contract to receive ETH
+    receive() external payable {
+        totalValueReceived += msg.value;
+        emit ValueReceived(msg.sender, msg.value);
+    }
+}
+
+/// @title WhitelistReceiver
+/// @notice Example: A contract that whitelists addresses from L1
+contract WhitelistReceiver is BridgeReceiver {
+    // L1 admin address that can whitelist
+    address public immutable l1Admin;
+
+    // Whitelist storage
+    mapping(address => bool) public whitelist;
+
+    event AddressWhitelisted(address indexed addr, address indexed by, uint64 srcChainId);
+
+    constructor(address _l1Admin) {
+        l1Admin = _l1Admin;
+    }
+
+    function _processMessage(
+        address _from,
+        uint64 _srcChainId,
+        bytes calldata _data
+    ) internal override {
+        // Only accept messages from our L1 admin
+        require(_from == l1Admin, "WhitelistReceiver: unauthorized sender");
+
+        // Decode the address to whitelist
+        address toWhitelist = abi.decode(_data, (address));
+
+        // Add to whitelist
+        whitelist[toWhitelist] = true;
+
+        emit AddressWhitelisted(toWhitelist, _from, _srcChainId);
+    }
+}

--- a/skills/mainnet/examples/solidity/CrossChainCounter.sol
+++ b/skills/mainnet/examples/solidity/CrossChainCounter.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IBridge
+/// @notice Interface for Taiko Bridge message sending and receiving
+interface IBridge {
+    struct Message {
+        uint64 id;
+        uint64 fee;
+        uint32 gasLimit;
+        address from;
+        uint64 srcChainId;
+        address srcOwner;
+        uint64 destChainId;
+        address destOwner;
+        address to;
+        uint256 value;
+        bytes data;
+    }
+
+    struct Context {
+        bytes32 msgHash;
+        address from;
+        uint64 srcChainId;
+    }
+
+    function sendMessage(Message calldata _message)
+        external
+        payable
+        returns (bytes32 msgHash, Message memory message);
+
+    function context() external view returns (Context memory);
+}
+
+/// @title CrossChainCounter
+/// @notice Example contract demonstrating bidirectional cross-chain messaging
+/// @dev Deploy on both L1 (Ethereum) and L2 (Taiko Alethia) with each other's address
+///
+/// This example shows:
+/// 1. How to send messages from L2 to L1
+/// 2. How to receive messages from L1 on L2
+/// 3. How to maintain synchronized state across chains
+///
+/// Deployment:
+/// 1. Deploy on L2 (Taiko Alethia) with L2 bridge address
+/// 2. Deploy on L1 (Ethereum) with L1 bridge address
+/// 3. Call setRemoteCounter() on each with the other's address
+///
+/// Build with: FOUNDRY_PROFILE=layer2 forge build
+contract CrossChainCounter {
+    // Bridge addresses
+    // L2 (Taiko Alethia): 0x1670000000000000000000000000000000000001
+    // L1 (Ethereum):      0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC
+    address public immutable bridge;
+
+    // Chain IDs
+    uint64 public constant L1_CHAIN_ID = 1; // Ethereum Mainnet
+    uint64 public constant L2_CHAIN_ID = 167000; // Taiko Alethia
+
+    // Remote counter contract address (on the other chain)
+    address public remoteCounter;
+
+    // Counter state
+    uint256 public count;
+    uint256 public lastSyncedCount;
+    uint64 public lastSyncChainId;
+
+    // Events
+    event CountIncremented(uint256 newCount, address by);
+    event SyncRequested(uint256 count, uint64 destChainId, bytes32 msgHash);
+    event SyncReceived(uint256 count, uint64 srcChainId, address from);
+
+    // Errors
+    error NotBridge();
+    error NotRemoteCounter();
+    error RemoteCounterNotSet();
+    error InvalidChainId();
+
+    constructor(address _bridge) {
+        bridge = _bridge;
+    }
+
+    /// @notice Set the remote counter contract address
+    /// @param _remoteCounter Address of CrossChainCounter on the other chain
+    function setRemoteCounter(address _remoteCounter) external {
+        // In production, add access control here
+        remoteCounter = _remoteCounter;
+    }
+
+    /// @notice Increment the counter locally
+    function increment() external {
+        count++;
+        emit CountIncremented(count, msg.sender);
+    }
+
+    /// @notice Sync the current count to the remote chain
+    /// @param _gasLimit Gas limit for the message execution on destination
+    /// @dev Requires ETH for the bridge fee
+    function syncToRemote(uint32 _gasLimit) external payable {
+        if (remoteCounter == address(0)) revert RemoteCounterNotSet();
+
+        // Determine destination chain
+        uint64 destChainId = block.chainid == L2_CHAIN_ID ? L1_CHAIN_ID : L2_CHAIN_ID;
+
+        // Encode the sync message
+        bytes memory data = abi.encodeCall(this.receiveSync, (count));
+
+        // Create the bridge message
+        IBridge.Message memory message = IBridge.Message({
+            id: 0, // Assigned by bridge
+            fee: 0, // Set by bridge based on msg.value
+            gasLimit: _gasLimit,
+            from: address(0), // Set by bridge
+            srcChainId: 0, // Set by bridge
+            srcOwner: msg.sender,
+            destChainId: destChainId,
+            destOwner: msg.sender,
+            to: remoteCounter,
+            value: 0,
+            data: data
+        });
+
+        // Send the message
+        (bytes32 msgHash,) = IBridge(bridge).sendMessage{value: msg.value}(message);
+
+        emit SyncRequested(count, destChainId, msgHash);
+    }
+
+    /// @notice Receive a sync from the remote chain
+    /// @param _count The count value from the remote chain
+    /// @dev Only callable by the bridge
+    function receiveSync(uint256 _count) external {
+        if (msg.sender != bridge) revert NotBridge();
+
+        // Get the message context
+        IBridge.Context memory ctx = IBridge(bridge).context();
+
+        // Verify the sender is our remote counter
+        if (ctx.from != remoteCounter) revert NotRemoteCounter();
+
+        // Update synced state
+        lastSyncedCount = _count;
+        lastSyncChainId = ctx.srcChainId;
+
+        emit SyncReceived(_count, ctx.srcChainId, ctx.from);
+    }
+
+    /// @notice Get the current chain's role
+    /// @return "L1" or "L2" based on chain ID
+    function getChainRole() external view returns (string memory) {
+        if (block.chainid == L1_CHAIN_ID) return "L1";
+        if (block.chainid == L2_CHAIN_ID) return "L2";
+        return "Unknown";
+    }
+
+    /// @notice Estimate the fee for syncing
+    /// @dev This is a simplified estimate; actual fees depend on gas prices
+    function estimateSyncFee(uint32 _gasLimit) external view returns (uint256) {
+        // Simplified fee estimation
+        // In production, query the bridge for actual fee calculation
+        return _gasLimit * tx.gasprice;
+    }
+}
+
+/// @title CrossChainCounterFactory
+/// @notice Factory for deploying CrossChainCounter with correct bridge addresses
+contract CrossChainCounterFactory {
+    // Known bridge addresses
+    address public constant L1_BRIDGE = 0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC;
+    address public constant L2_BRIDGE = 0x1670000000000000000000000000000000000001;
+
+    event CounterDeployed(address indexed counter, address indexed bridge, uint256 chainId);
+
+    /// @notice Deploy a CrossChainCounter with the correct bridge for this chain
+    function deploy() external returns (address) {
+        address bridgeAddr;
+
+        if (block.chainid == 1) {
+            // L1 Ethereum Mainnet
+            bridgeAddr = L1_BRIDGE;
+        } else if (block.chainid == 167000) {
+            // L2 Taiko Alethia
+            bridgeAddr = L2_BRIDGE;
+        } else {
+            revert("Unsupported chain");
+        }
+
+        CrossChainCounter counter = new CrossChainCounter(bridgeAddr);
+
+        emit CounterDeployed(address(counter), bridgeAddr, block.chainid);
+
+        return address(counter);
+    }
+}

--- a/skills/mainnet/examples/solidity/README.md
+++ b/skills/mainnet/examples/solidity/README.md
@@ -1,0 +1,39 @@
+# Solidity Examples
+
+Cross-chain messaging examples. See `../../assets/foundry-template/` for project setup.
+
+## BridgeReceiver.sol
+
+Receive cross-chain messages from L1 with replay protection.
+
+```solidity
+BridgeReceiver receiver = new BridgeReceiver();
+// L1 sends message via Bridge -> calls onMessageReceived()
+```
+
+## CrossChainCounter.sol
+
+Bidirectional counter with state sync.
+
+```bash
+# Deploy factory
+FOUNDRY_PROFILE=layer2 forge create src/CrossChainCounter.sol:CrossChainCounterFactory \
+  --rpc-url https://rpc.mainnet.taiko.xyz --private-key $PRIVATE_KEY
+
+# Increment and sync
+cast send $COUNTER "increment()" --rpc-url ... --private-key $PRIVATE_KEY
+cast send $COUNTER "syncToRemote(uint32)" 200000 --value 0.001ether --rpc-url ... --private-key $PRIVATE_KEY
+```
+
+## Chain Config
+
+| Chain | ID | Bridge |
+|-------|------|--------|
+| Ethereum L1 | 1 | `0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC` |
+| Taiko L2 | 167000 | `0x1670000000000000000000000000000000000001` |
+
+## Notes
+
+- Always use `FOUNDRY_PROFILE=layer2` for Taiko L2
+- L2->L1 messages require merkle proof after finalization
+- Bridge fees paid via `msg.value`

--- a/skills/mainnet/references/contract-addresses.md
+++ b/skills/mainnet/references/contract-addresses.md
@@ -1,0 +1,137 @@
+# Taiko Mainnet Contract Addresses
+
+Source: [mainnet-contract-logs-L1.md](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/deployments/mainnet-contract-logs-L1.md) and [mainnet-contract-logs-L2.md](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/deployments/mainnet-contract-logs-L2.md)
+
+## L1 Contracts (Ethereum Mainnet - Chain ID: 1)
+
+### Core Protocol
+
+| Contract | Address |
+|----------|---------|
+| Inbox (TaikoInbox) | `0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a` |
+| TAIKO Token | `0x10dea67478c5F8C5E2D90e5E9B26dBe60c54d800` |
+| Forced Inclusion Store | `0x05d88855361808fA1d7fc28084Ef3fCa191c4e03` |
+| Taiko Wrapper | `0x9F9D2fC7abe74C79f86F0D1212107692430eef72` |
+| SharedResolver | `0x8Efa01564425692d0a0838DC10E300BD310Cb43e` |
+| Rollup Address Resolver | `0x5A982Fb1818c22744f5d7D36D0C4c9f61937b33a` |
+
+### Preconfirmation
+
+| Contract | Address |
+|----------|---------|
+| Preconf Whitelist | `0xFD019460881e6EeC632258222393d5821029b2ac` |
+| Preconf Router | `0xD5AA0e20e8A6e9b04F080Cf8797410fafAa9688a` |
+
+### Bridge & Vaults (L1)
+
+| Contract | Address |
+|----------|---------|
+| Bridge | `0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC` |
+| SignalService | `0x9e0a24964e5397B566c1ed39258e21aB5E35C77C` |
+| ERC20Vault | `0x996282cA11E5DEb6B5D122CC3B9A1FcAAD4415Ab` |
+| ERC721Vault | `0x0b470dd3A0e1C41228856Fb319649E7c08f419Aa` |
+| ERC1155Vault | `0xaf145913EA4a56BE22E120ED9C24589659881702` |
+| QuotaManager | `0x91f67118DD47d502B1f0C354D0611997B022f29E` |
+
+### Bridged Token Implementations (L1)
+
+| Contract | Address |
+|----------|---------|
+| BridgedERC20 (impl) | `0x65666141a541423606365123Ed280AB16a09A2e1` |
+| BridgedERC721 (impl) | `0xC3310905E2BC9Cfb198695B75EF3e5B69C6A1Bf7` |
+| BridgedERC1155 (impl) | `0x3c90963cFBa436400B0F9C46Aa9224cB379c2c40` |
+
+### Verifiers
+
+| Contract | Address |
+|----------|---------|
+| Proof Verifier (Compose) | `0xB16931e78d0cE3c9298bbEEf3b5e2276D34b8da1` |
+| SGX Reth Verifier | `0x9e322fC59b8f4A29e6b25c3a166ac1892AA30136` |
+| SGX Geth Verifier | `0x7e6409e9b6c5e2064064a6cC994f9a2e95680782` |
+| RISC0 Reth Verifier | `0x73Ee496dA20e5C65340c040B0D8c3C891C1f74AE` |
+| SP1 Reth Verifier | `0xbee1040D0Aab17AE19454384904525aE4A3602B9` |
+
+### Notable External Tokens (L1)
+
+| Token | Address |
+|-------|---------|
+| WETH | `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2` |
+| USDT | `0xdAC17F958D2ee523a2206206994597C13D831ec7` |
+| USDC | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+
+---
+
+## L2 Contracts (Taiko Alethia - Chain ID: 167000)
+
+### Core Protocol (Predefined Addresses)
+
+| Contract | Address |
+|----------|---------|
+| Bridge | `0x1670000000000000000000000000000000000001` |
+| ERC20Vault | `0x1670000000000000000000000000000000000002` |
+| ERC721Vault | `0x1670000000000000000000000000000000000003` |
+| ERC1155Vault | `0x1670000000000000000000000000000000000004` |
+| SignalService | `0x1670000000000000000000000000000000000005` |
+| SharedResolver | `0x1670000000000000000000000000000000000006` |
+| TaikoAnchor | `0x1670000000000000000000000000000000010001` |
+| RollupResolver | `0x1670000000000000000000000000000000010002` |
+
+### Bridged TAIKO Token
+
+| Token | Address |
+|-------|---------|
+| TAIKO (Bridged) | `0xA9d23408b9bA935c230493c40C73824Df71A0975` |
+
+### Other Bridged Tokens
+
+| Token | Address |
+|-------|---------|
+| USDC (Native) | `0x07d83526730c7438048D55A4fc0b850e2aaB6f0b` |
+| WETH | `0xA51894664A773981C6C112C43ce576f315d5b1B6` |
+
+### Governance
+
+| Contract | Address |
+|----------|---------|
+| DelegateController | `0xfA06E15B8b4c5BF3FC5d9cfD083d45c53Cbe8C7C` |
+
+### Pacaya Resolvers (L2)
+
+| Contract | Address |
+|----------|---------|
+| SharedResolver (Pacaya) | `0xc32277f541bBADAA260337E71Cea53871D310DC8` |
+| RollupResolver (Pacaya) | `0x73251237d8F1B99e9966bB054722F3446195Ea56` |
+
+### Bridged Token Implementations (L2)
+
+| Contract | Address |
+|----------|---------|
+| BridgedERC20 (impl) | `0x98161D67f762A9E589E502348579FA38B1Ac47A8` |
+| BridgedERC721 (impl) | `0x0167000000000000000000000000000000010097` |
+| BridgedERC1155 (impl) | `0x0167000000000000000000000000000000010098` |
+
+### Utility Contracts
+
+| Contract | Address |
+|----------|---------|
+| Multicall3 | `0xca11bde05977b3631167028862be2a173976ca11` |
+| Safe Singleton Factory | `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` |
+
+---
+
+## Ownership
+
+| Role | Address |
+|------|---------|
+| L1 Owner (Taiko DAO) | `0x9CDf589C941ee81D75F34d3755671d614f7cf261` |
+| L2 Owner (DelegateController) | `0xfA06E15B8b4c5BF3FC5d9cfD083d45c53Cbe8C7C` |
+| L2 Admin | `0xCa5b76Cc7A38b86Db11E5aE5B1fc9740c3bA3DE8` |
+
+---
+
+## Notes
+
+- Addresses are proxy addresses where proxy/impl are both provided
+- L2 system contracts use predefined `0x167000...` range
+- For Solidity constants, see `assets/foundry-template/src/TaikoMainnetAddresses.sol`
+- Mainnet is governed by the Taiko DAO on L1

--- a/skills/mainnet/references/network-config.md
+++ b/skills/mainnet/references/network-config.md
@@ -1,0 +1,183 @@
+# Taiko Mainnet Network Configuration
+
+## Network Details
+
+### Taiko Alethia (L2)
+
+| Property | Value |
+|----------|-------|
+| **Network Name** | Taiko Alethia |
+| **Chain ID** | `167000` (hex: `0x28c58`) |
+| **Symbol** | ETH |
+| **RPC URL** | `https://rpc.mainnet.taiko.xyz` |
+
+### Ethereum Mainnet (L1)
+
+| Property | Value |
+|----------|-------|
+| **Network Name** | Ethereum Mainnet |
+| **Chain ID** | `1` (hex: `0x1`) |
+| **Symbol** | ETH |
+| **RPC Endpoints** | See [chainlist.org/chain/1](https://chainlist.org/chain/1) |
+
+---
+
+## Alternative RPC Endpoints
+
+| Provider | URL |
+|----------|-----|
+| Taiko (Official) | `https://rpc.mainnet.taiko.xyz` |
+| Taiko (Alt) | `https://rpc.taiko.xyz` |
+| Ankr | `https://rpc.ankr.com/taiko` |
+| dRPC | `https://taiko.drpc.org` |
+| PublicNode | `https://taiko-rpc.publicnode.com` |
+
+**Note:** Public RPC endpoints are rate limited. For production use, run your own node or use a third-party RPC provider.
+
+---
+
+## Block Explorers
+
+### Taiko Alethia
+
+| Explorer | URL |
+|----------|-----|
+| Taikoscan | https://taikoscan.io |
+| Blockscout | https://blockscout.mainnet.taiko.xyz |
+
+### Ethereum Mainnet
+
+| Explorer | URL |
+|----------|-----|
+| Etherscan | https://etherscan.io |
+| Beacon Explorer | https://beaconcha.in |
+
+---
+
+## API Endpoints
+
+### Verification APIs
+
+| Service | API URL |
+|---------|---------|
+| Taikoscan | `https://api.taikoscan.io/api` |
+| Taikoscan (v2) | `https://api.etherscan.io/v2/api?chainid=167000` |
+| Blockscout | `https://blockscoutapi.mainnet.taiko.xyz/api?` |
+
+### Bridge & Relayer
+
+| Service | URL |
+|---------|-----|
+| Official Bridge | https://bridge.taiko.xyz |
+| Bridge Relayer API | https://relayer.taiko.xyz |
+
+---
+
+## Protocol Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Liveness Bond | 125 TAIKO |
+| Proving Window | 120 minutes |
+| Cooldown | 120 minutes |
+| Proof Types | TEE + TEE, TEE + ZK |
+| ZK Coverage | 100% |
+| Basefee Sharing | 75% |
+
+---
+
+## Gas Configuration
+
+| Parameter | Taiko Alethia | Ethereum |
+|-----------|---------------|----------|
+| Block Gas Limit | 241,000,000 | 36,000,000 |
+| Block Gas Target | 40,000,000 (per L1 block) | 18,000,000 |
+| Block Time | ~2-6 seconds | 12 seconds |
+
+---
+
+## Getting ETH on Taiko Alethia
+
+Taiko Alethia is a **mainnet** — real ETH is required.
+
+1. **Acquire ETH** on Ethereum Mainnet
+2. **Bridge to Taiko Alethia** via https://bridge.taiko.xyz
+
+**Note:** Bridging back from L2 to L1 takes up to 24 hours due to the cooldown period.
+
+---
+
+## Wallet Configuration
+
+### MetaMask (Taiko Alethia)
+
+```json
+{
+  "chainId": "0x28c58",
+  "chainName": "Taiko Alethia",
+  "nativeCurrency": {
+    "name": "Ethereum",
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "rpcUrls": ["https://rpc.mainnet.taiko.xyz"],
+  "blockExplorerUrls": ["https://taikoscan.io"]
+}
+```
+
+### Manual Setup
+
+```
+Network Name: Taiko Alethia
+RPC URL: https://rpc.mainnet.taiko.xyz
+Chain ID: 167000
+Currency Symbol: ETH
+Block Explorer: https://taikoscan.io
+```
+
+---
+
+## EVM Compatibility
+
+| Property | Value |
+|----------|-------|
+| ZK-EVM Type | Type-1 (fully Ethereum-equivalent) |
+| EVM Version | Shanghai |
+| Supported Opcodes | All standard EVM opcodes |
+| Precompiles | All Ethereum precompiles |
+
+---
+
+## Development Resources
+
+| Resource | URL |
+|----------|-----|
+| Official Docs | https://docs.taiko.xyz |
+| Bridge UI | https://bridge.taiko.xyz |
+| Code Diff Tool | https://codediff.taiko.xyz |
+| Status Page | https://status.taiko.xyz |
+| Proof Dashboard | https://proofs.taiko.xyz |
+| Protocol Releases | https://github.com/taikoxyz/taiko-mono/releases?q=alethia-protocol |
+| L1 Contract Logs | https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/deployments/mainnet-contract-logs-L1.md |
+| L2 Contract Logs | https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/deployments/mainnet-contract-logs-L2.md |
+| Discord | https://discord.gg/taikoxyz |
+| GitHub | https://github.com/taikoxyz/taiko-mono |
+
+---
+
+## Running a Node
+
+| Guide | URL |
+|-------|-----|
+| Docker | https://docs.taiko.xyz/guides/node-operators/run-a-taiko-alethia-node-with-docker/ |
+| From Source | https://docs.taiko.xyz/guides/node-operators/build-a-taiko-alethia-node-from-source/ |
+
+### Simple Taiko Node
+
+```bash
+git clone https://github.com/taikoxyz/simple-taiko-node
+cd simple-taiko-node
+cp .env.sample .env
+# Edit .env with your configuration
+docker compose up -d
+```


### PR DESCRIPTION
## Summary

- Add complete `/taiko:mainnet` skill mirroring the hoodi skill structure
- Add `taiko-mainnet-developer` agent with mainnet-specific guidance and safety checks
- Update README with mainnet support (removes "Coming soon" label)

## New Files (19 files)

### Skill (`skills/mainnet/`)
- `SKILL.md` — Main skill with quick reference, deploy/verify commands, x402 config
- `references/contract-addresses.md` — L1 (Ethereum) + L2 (Taiko) protocol addresses
- `references/network-config.md` — RPC endpoints, explorers, gas config, wallet setup

### Agent
- `agents/taiko-mainnet-developer.md` — Mainnet subagent (sonnet model, extra safety rules)

### Foundry Template (`skills/mainnet/assets/foundry-template/`)
- `TaikoMainnetAddresses.sol` — All protocol addresses as Solidity constants
- `Counter.sol`, `Deploy.s.sol`, `Counter.t.sol` — Example contracts and tests
- `foundry.toml` — Configured for Taiko mainnet + Ethereum mainnet
- `.env.example`, `remappings.txt`, `.gitignore`, `README.md`

### Examples
- Python: `verify_signal.py`, `calc_blockhash.py` (mainnet RPC + addresses)
- Solidity: `BridgeReceiver.sol`, `CrossChainCounter.sol` (mainnet chain IDs + bridges)

## Key Mainnet Parameters

| Property | Value |
|----------|-------|
| Network Name | Taiko Alethia |
| Chain ID | 167000 |
| L1 | Ethereum Mainnet (chain ID 1) |
| RPC | `https://rpc.mainnet.taiko.xyz` |
| Explorer | `https://taikoscan.io` |
| Bridge | `https://bridge.taiko.xyz` |
| L2 Bridge | `0x1670000000000000000000000000000000000001` |
| L1 Bridge | `0xd60247c6848B7Ca29eDdF63AA924E53dB6Ddd8EC` |

## Data Sources

- [mainnet-contract-logs-L1.md](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/deployments/mainnet-contract-logs-L1.md)
- [mainnet-contract-logs-L2.md](https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/deployments/mainnet-contract-logs-L2.md)
- [docs.taiko.xyz](https://docs.taiko.xyz)
- [taikoscan.io](https://taikoscan.io)

## Test plan

- [ ] Verify `/taiko:mainnet` skill loads correctly in Claude Code
- [ ] Verify `taiko-mainnet-developer` agent triggers on mainnet keywords
- [ ] Cross-check all L1/L2 contract addresses against source logs
- [ ] Confirm Foundry template builds with `FOUNDRY_PROFILE=layer2`
- [ ] Test fork tests against `https://rpc.mainnet.taiko.xyz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)