### PR TITLE
Enable dual-format distribution: Agent Skills + Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ ENV/
 # Foundry
 out/
 cache/
+.cache/
 broadcast/
 *.log
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ An AI agent plugin for developing on Taiko networks.
 
 ## Installation
 
+### Any AI agent (Cursor, Copilot, Codex, Windsurf, Cline, etc.)
+
+```bash
+npx skills add taikoxyz/taiko-ai
+```
+
+### Claude Code (full experience with agent behavior, tool scoping, and branding)
+
 ```bash
 /plugin marketplace add taikoxyz/taiko-ai
 /plugin install taiko@taikoxyz

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "taiko-ai",
+  "private": true
+}


### PR DESCRIPTION
Add package.json and update README to support both installation methods:
- `npx skills add taikoxyz/taiko-ai` for 40+ AI agents (Cursor, Copilot, Codex, Gemini, etc.)
- Claude Code plugin marketplace for enhanced agent experience with tool scoping and branding

Single codebase maintains both distribution formats with zero duplication. Claude Code plugin retains all rich agent behavior while other agents access SKILL.md + references + examples + assets.