### PR TITLE
Release v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "taiko-ai",
-  "private": true
+  "private": false
 }


### PR DESCRIPTION
## Summary

- Add taiko-node skill and agent for node setup/operations (Docker + source build)
- Consolidate network references into single file, rename Alethia to Mainnet
- Slim down taiko-developer agent, make descriptions model-agnostic
- Bump version to 1.3.0, mark package as public

## Test plan

- [ ] Verify plugin installs from marketplace at v1.3.0
- [ ] Verify `/taiko` and `/taiko-node` skills load correctly