### PR TITLE
chore: release v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taiko-ai",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taiko-ai",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "workspaces": [
         "mcp-servers/*",
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taiko-ai",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "workspaces": [
     "mcp-servers/*",


### PR DESCRIPTION
Bump the root package version from 1.5.0 to 1.6.0. Update package-lock metadata to keep the lockfile in sync with the release version.